### PR TITLE
Unable to choose a translation for "1 dzień|:count dni" with locale "pl" for value "5"

### DIFF
--- a/src/lang/pl/date.php
+++ b/src/lang/pl/date.php
@@ -19,7 +19,7 @@ return array(
     'year'      => '1 rok|:count lata|:count lat',
     'month'     => '1 miesiąc|:count miesiące|:count miesięcy',
     'week'      => '1 tydzień|:count tygodnie|:count tygodni',
-    'day'       => '1 dzień|:count dni',
+    'day'       => '1 dzień|:count dni|:count dni',
     'hour'      => '1 godzina|:count godziny|:count godzin',
     'minute'    => '1 minuta|:count minuty|:count minut',
     'second'    => '1 sekunda|:count sekundy|:count sekund',


### PR DESCRIPTION
Unable to choose a translation for "1 dzień|:count dni" with locale "pl" for value "5". Double check that this translation has the correct plural options (e.g. "There is one apple|There are %count% apples")

That strange because in polish we have:
1 dzień
2 dni
5 dni
1576352745 dni

so only "dzień" and "dni" but translator looking for... 5 ?
