### PR TITLE
Add Russian to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This package contains language files for the following languages:
  - Italian
  - Polish
  - Portuguese
+ - Russian
  - Serbian
  - Spanish
  - Swedish (incomplete)


### PR DESCRIPTION
It seems that Russian language is missing in the list of supported languages.
