### PR TITLE
Updated missing translations

### DIFF
--- a/src/lang/sv/date.php
+++ b/src/lang/sv/date.php
@@ -14,13 +14,13 @@ return array(
 
     'ago'       => ':time sedan',
     'from_now'  => ':time från nu',
-    'after'     => '',
-    'before'    => '',
+    'after'     => ':time efter',
+    'before'    => ':time före',
     'year'      => '1 år|:count år',
     'month'     => '1 månad|:count månader',
     'week'      => '1 vecka|:count veckor',
     'day'       => '1 dag|:count dagar',
-    'hour'      => '1 timma|:count timmar',
+    'hour'      => '1 timme|:count timmar',
     'minute'    => '1 minut|:count minuter',
     'second'    => '1 sekund|:count sekunder',
 


### PR DESCRIPTION
Also changed from "timma" to "timme". When talking about time "timme" is preferred. "Timma" is a form of dialect http://sv.wikipedia.org/wiki/Timme
