### PR TITLE
corrected temporal prepositions for German

### DIFF
--- a/src/lang/de/date.php
+++ b/src/lang/de/date.php
@@ -13,9 +13,9 @@ return array(
     */
 
     'ago'       => 'vor :time',
-    'from_now'  => ':time von jetzt',
-    'after'     => ':time nach',
-    'before'    => ':time vor',
+    'from_now'  => 'in :time',
+    'after'     => ':time später',
+    'before'    => ':time vorher',
     'year'      => '1 Jahr|:count Jahre',
     'month'     => '1 Monat|:count Monate',
     'week'      => '1 Woche|:count Wochen',


### PR DESCRIPTION
The temporal prepositions (e.g. before, after, ...) sounded wrong for the German locale. This should fix it.
