### PR TITLE
Fixed typo in 'August' in Serbian; Added Serbo-croatian (sh.php) for backwards compatibility.

### DIFF
--- a/src/Lang/sh.php
+++ b/src/Lang/sh.php
@@ -1,0 +1,48 @@
+<?php
+
+return array(
+
+    /*
+    |--------------------------------------------------------------------------
+    | Date Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the date library. Each line can
+    | have a singular and plural translation separated by a '|'.
+    |
+    */
+
+    'ago'       => 'pre :time',
+    'from_now'  => 'za :time',
+    'after'     => 'nakon :time',
+    'before'    => ':time raniјe',
+    'year'      => ':count godina|:count godine|:count godina',
+    'month'     => ':count mesec|:count meseca|:count meseci',
+    'week'      => ':count nedelja|:count nedelje|:count nedelja',
+    'day'       => ':count dan|:count dana|:count dana',
+    'hour'      => ':count čas|:count časa|:count časova',
+    'minute'    => ':count minut|:count minuta|:count minuta',
+    'second'    => ':count sekund|:count sekunda|:count sekundi',
+
+    'january'   => 'јanuar',
+    'february'  => 'februar',
+    'march'     => 'mart',
+    'april'     => 'april',
+    'may'       => 'maј',
+    'june'      => 'јun',
+    'july'      => 'јul',
+    'august'    => 'avgust',
+    'september' => 'septembar',
+    'october'   => 'oktobar',
+    'november'  => 'novembar',
+    'december'  => 'decembar',
+
+    'monday'    => 'ponedeljak',
+    'tuesday'   => 'utorak',
+    'wednesday' => 'sreda',
+    'thursday'  => 'četvrtak',
+    'friday'    => 'petak',
+    'saturday'  => 'subota',
+    'sunday'    => 'nedelja',
+
+);

--- a/src/Lang/sr.php
+++ b/src/Lang/sr.php
@@ -31,7 +31,7 @@ return array(
     'may'       => 'мај',
     'june'      => 'јун',
     'july'      => 'јул',
-    'august'    => 'авгус',
+    'august'    => 'август',
     'september' => 'септембар',
     'october'   => 'октобар',
     'november'  => 'новембар',


### PR DESCRIPTION
There was a slight typo in Serbian localization, this fixes it.

Although Serbo-croatian is out of use, there still may be certain situations where people would want to use it. This commit adds Serbo-croatian localization.