### PR TITLE
Adds Traditional Chinese for Hong Kong.

### DIFF
--- a/src/Lang/zh-HK.php
+++ b/src/Lang/zh-HK.php
@@ -1,0 +1,48 @@
+<?php
+
+return array(
+
+    /*
+    |--------------------------------------------------------------------------
+    | Date Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the date library. Each line can
+    | have a singular and plural translation separated by a '|'.
+    |
+    */
+
+    'ago'       => ':time前',
+    'from_now'  => '距現在 :time',
+    'after'     => ':time後',
+    'before'    => ':time前',
+    'year'      => ':count 年',
+    'month'     => ':count 月',
+    'week'      => ':count 周',
+    'day'       => ':count 天',
+    'hour'      => ':count 小時',
+    'minute'    => ':count 分鐘',
+    'second'    => ':count 秒',
+
+    'january'   => '一月',
+    'february'  => '二月',
+    'march'     => '三月',
+    'april'     => '四月',
+    'may'       => '五月',
+    'june'      => '六月',
+    'july'      => '七月',
+    'august'    => '八月',
+    'september' => '九月',
+    'october'   => '十月',
+    'november'  => '十一月',
+    'december'  => '十二月',
+
+    'monday'    => '星期一',
+    'tuesday'   => '星期二',
+    'wednesday' => '星期三',
+    'thursday'  => '星期四',
+    'friday'    => '星期五',
+    'saturday'  => '星期六',
+    'sunday'    => '星期日',
+
+);


### PR DESCRIPTION
It's effectively the same as zh-TW, but we use zh-HK.