### PR TITLE
Date.php: Silently fall back to en when the locale isn't supported

### DIFF
--- a/src/Date.php
+++ b/src/Date.php
@@ -375,6 +375,14 @@ class Date extends Carbon {
         // Use RFC 5646 for filenames.
         $resourcePath = __DIR__ . '/Lang/' . str_replace('_', '-', $locale) . '.php';
 
+        // Check if the locale is supported
+        if ( ! is_readable($resourcePath))
+        {
+            // Silently fall back to "en"
+            static::setLocale("en");
+            return;
+        }
+
         // Symfony locale format.
         $locale = str_replace('-', '_', $locale);
 

--- a/tests/TranslationTest.php
+++ b/tests/TranslationTest.php
@@ -165,4 +165,12 @@ class TranslationTest extends PHPUnit_Framework_TestCase
         $date = new Date('10 march 2015');
         $this->assertSame('10 мартa 2015', $date->format('j F Y'));
     }
+
+    public function testFallbackLocale()
+    {
+        Date::setLocale('doge');
+
+        $date = new Date();
+        $this->assertSame('en', $date->getLocale());
+    }
 }


### PR DESCRIPTION
Currently, a fatal error occurs when the program tries to `setLocale()` to an unsupported one (e.g. `ta`). Maybe we should silently fall back to `en` in such situation.