### PR TITLE
Option to override language file

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ You can also add it as a Facade in `config/app.php`:
 'Date' => Jenssegers\Date\Date::class,
 ```
 
+To override any default language file in Laravel newer than 5.1, create file as `resources/lang/vendor/Jenssegers/Date/{locale}.php`:
+
 Languages
 ---------
 

--- a/src/Date.php
+++ b/src/Date.php
@@ -370,10 +370,10 @@ class Date extends Carbon {
      * @param  string $locale
      * @return void
      */
-    public static function setLocale($locale)
+    public static function setLocale($locale, $resourcePath = null)
     {
         // Use RFC 5646 for filenames.
-        $resourcePath = __DIR__ . '/Lang/' . str_replace('_', '-', $locale) . '.php';
+        $resourcePath or $resourcePath = __DIR__ . '/Lang/' . str_replace('_', '-', $locale) . '.php';
 
         // Symfony locale format.
         $locale = str_replace('-', '_', $locale);

--- a/src/Date.php
+++ b/src/Date.php
@@ -368,6 +368,7 @@ class Date extends Carbon {
      * Set the current locale.
      *
      * @param  string $locale
+     * @param  string $resourcePath Optional parameter to override resource path
      * @return void
      */
     public static function setLocale($locale, $resourcePath = null)

--- a/src/DateServiceProvider.php
+++ b/src/DateServiceProvider.php
@@ -20,6 +20,15 @@ class DateServiceProvider extends ServiceProvider {
     {
         $locale = $this->app['translator']->getLocale();
 
+        // Option to have custom resource file for Laravel ^5.1
+        $laravel_version = explode('.', $this->app['app']->version());
+        if ($laravel_version[0] == 5 && $laravel_version[1] >= 1) {
+            $resource = $this->app['path.lang'] . '\vendor\\' . __NAMESPACE__ . '\\' . $locale . '.php';
+            file_exists($resource) or $resource = null;
+            Date::setLocale($locale, $resource);
+            return;
+        }
+
         Date::setLocale($locale);
     }
 

--- a/src/DateServiceProvider.php
+++ b/src/DateServiceProvider.php
@@ -20,10 +20,10 @@ class DateServiceProvider extends ServiceProvider {
     {
         $locale = $this->app['translator']->getLocale();
 
-        // Option to have custom resource file for Laravel ^5.1
+        // Option to have custom resource file for Laravel >=5.1
         $laravel_version = explode('.', $this->app['app']->version());
         if ($laravel_version[0] == 5 && $laravel_version[1] >= 1) {
-            $resource = $this->app['path.lang'] . '\vendor\\' . __NAMESPACE__ . '\\' . $locale . '.php';
+            $resource = $this->app['path.lang'] . '/vendor/' . __NAMESPACE__ . '/' . $locale . '.php';
             file_exists($resource) or $resource = null;
             Date::setLocale($locale, $resource);
             return;


### PR DESCRIPTION
Adds an option to create custom language file in directory mentioned in https://laravel.com/docs/5.2/localization#overriding-vendor-language-files, to override existing or creating new language file in Laravel 5.1 and 5.2.

Solves issue #188
