### PR TITLE
Added functionality to translate a pluralized string

### DIFF
--- a/src/Date.php
+++ b/src/Date.php
@@ -437,7 +437,37 @@ class Date extends Carbon
 
         $lines = array_intersect_key($all['messages'], array_flip((array) $keys));
 
+        // Some languages (e.g. Russian) have different translations
+        // for month and day names.
+        // This requires us to split the strings first.
+
+        $aa = array_map(function($line) {
+                if (strpos($line, '|') === false) {
+                    // There is only option to translate this string.
+                    return [$line];
+                } else {
+                    // There are multiple options, delimited by a pipe.
+                    $options = explode('|', $line);
+
+                    return array_map(function($option){
+                        // First remove ':count'.
+                        $option = trim(str_replace(':count', null, $option));
+
+                        // Secondly remove the number parameter.
+                        $option = preg_replace('/({\d+(,(\d+|Inf))?}|\[\d+(,(\d+|Inf))?\])/', null, $option);
+
+                        return $option;
+                    }, $options);
+                }
+            }, $lines);
+
+        $translated = str_ireplace($lines, array_keys($lines), $time);
+
         // Replace the translated words with the English words
-        return str_ireplace($lines, array_keys($lines), $time);
+        foreach ($aa as $key => $values) {
+            $translated = str_ireplace($values, $key, $translated);
+        }
+
+        return $translated;
     }
 }

--- a/src/Date.php
+++ b/src/Date.php
@@ -449,7 +449,7 @@ class Date extends Carbon
                 // There are multiple options, delimited by a pipe.
                 $options = explode('|', $line);
 
-                return array_map(function ($option){
+                return array_map(function ($option) {
                     // First remove ':count'.
                     $option = trim(str_replace(':count', null, $option));
 

--- a/src/Date.php
+++ b/src/Date.php
@@ -441,25 +441,25 @@ class Date extends Carbon
         // for month and day names.
         // This requires us to split the strings first.
 
-        $aa = array_map(function($line) {
-                if (strpos($line, '|') === false) {
-                    // There is only option to translate this string.
-                    return [$line];
-                } else {
-                    // There are multiple options, delimited by a pipe.
-                    $options = explode('|', $line);
+        $aa = array_map(function ($line) {
+            if (strpos($line, '|') === false) {
+                // There is only option to translate this string.
+                return [$line];
+            } else {
+                // There are multiple options, delimited by a pipe.
+                $options = explode('|', $line);
 
-                    return array_map(function($option){
-                        // First remove ':count'.
-                        $option = trim(str_replace(':count', null, $option));
+                return array_map(function ($option){
+                    // First remove ':count'.
+                    $option = trim(str_replace(':count', null, $option));
 
-                        // Secondly remove the number parameter.
-                        $option = preg_replace('/({\d+(,(\d+|Inf))?}|\[\d+(,(\d+|Inf))?\])/', null, $option);
+                    // Secondly remove the number parameter.
+                    $option = preg_replace('/({\d+(,(\d+|Inf))?}|\[\d+(,(\d+|Inf))?\])/', null, $option);
 
-                        return $option;
-                    }, $options);
-                }
-            }, $lines);
+                    return $option;
+                }, $options);
+            }
+        }, $lines);
 
         $translated = str_ireplace($lines, array_keys($lines), $time);
 

--- a/tests/TranslationTest.php
+++ b/tests/TranslationTest.php
@@ -172,4 +172,15 @@ class TranslationTest extends PHPUnit_Framework_TestCase
         $date = new Date('10 march 2015');
         $this->assertSame('10 мартa 2015', $date->format('j F Y'));
     }
+
+    public function testTranslateTimeString()
+    {
+        Date::setLocale('ru');
+        $date = Date::translateTimeString('понедельник 21 март 2015');
+        $this->assertSame('monday 21 march 2015', $date);
+
+        Date::setLocale('de');
+        $date = Date::translateTimeString('Montag 21 März 2015');
+        $this->assertSame('monday 21 march 2015', $date);
+    }
 }


### PR DESCRIPTION
This pull request is based on issue #198 

Some languages (e.g. Russian) have different translations for month and day names (e,g, depending on the grammatical case). The previous implementation of the `translateTimeString($time)` method only worked on strings, not respecting the translation file syntax.

This implementation (hopefully) correctly parses these multiple translation options in a single translation string and produces a (where possible) fully translated output string.

I added a test case to illustrate this new behavior: the German example works in the old and new version of the method, the Russian example however, only works with the translation algorithm.

As far as I can tell, I (thanks to the help of StyleCI) corrected all coding style which are due to this PR.

Please let me know what you think of this pull request and how I can improve it!