### PR TITLE
Add third argument to diffForHumans to match Carbon\Carbon

### DIFF
--- a/src/Date.php
+++ b/src/Date.php
@@ -96,7 +96,7 @@ class Date extends Carbon
      * @param  bool   $absolute Removes time difference modifiers ago, after, etc
      * @return string
      */
-    public function diffForHumans(Carbon $since = null, $absolute = false)
+    public function diffForHumans(Carbon $since = null, $absolute = false, $short = false)
     {
         // Get translator
         $lang = $this->getTranslator();


### PR DESCRIPTION
Carbon\Carbon::diffForHumans(Carbon\Carbon $other = NULL, $absolute = false, $short = false) has a new third argument and lack of it in Jenssegers\Date\Date::diffForHumans is not playing nicely.