### PR TITLE
fix error

### DIFF
--- a/src/Date.php
+++ b/src/Date.php
@@ -25,6 +25,13 @@ class Date extends Carbon
     protected static $fallbackLocale = 'en';
 
     /**
+     * The errors that can occur.
+     *
+     * @var array
+     */
+    protected static $lastErrors;
+
+    /**
      * Returns new DateTime object.
      *
      * @param  string              $time


### PR DESCRIPTION
I have some error after update `Cannot access property Jenssegers\Date\Date::$lastErrors` on `Date::createFromFormat('d.m.Y', $date)`, after re-init property to protected it was fixed.