### PR TITLE
Fix changing locale after app has booted

### DIFF
--- a/src/DateServiceProvider.php
+++ b/src/DateServiceProvider.php
@@ -18,6 +18,19 @@ class DateServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        $this->app['events']->listen('locale.changed', function() {
+            $this->setLocale();
+        });
+
+        $this->setLocale();
+    }
+
+    /**
+     * Set the locale.
+     *
+     */
+    protected function setLocale()
+    {
         $locale = $this->app['translator']->getLocale();
 
         Date::setLocale($locale);

--- a/src/DateServiceProvider.php
+++ b/src/DateServiceProvider.php
@@ -18,7 +18,7 @@ class DateServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->app['events']->listen('locale.changed', function() {
+        $this->app['events']->listen('locale.changed', function () {
             $this->setLocale();
         });
 


### PR DESCRIPTION
It's pretty common to have your app change the locale in a middleware. When the app boots up, it's very rare to actually know what the locale will be until the session is booted and locale is set.

This fixes those cases where the locale can be changed at any time after the app has booted.

As a side note, I would recommend to have a proper facade for `Date` because then you can defer loading of the service provider and translator module every request. Anyway that's for another PR.
