### PR TITLE
[Thai Translation] Fix: Remove trans_choice (always show as 1 xxx, in…

### DIFF
--- a/src/Lang/th.php
+++ b/src/Lang/th.php
@@ -12,17 +12,17 @@ return [
     |
     */
 
-    'ago'       => ':time ที่แล้ว',
-    'from_now'  => ':time จากนี้',
-    'after'     => 'หลัง:time',
-    'before'    => 'ก่อน:time',
-    'year'      => '1 ปี|:count ปี',
-    'month'     => '1 เดือน|:count เดือน',
-    'week'      => '1 สัปดาห์|:count สัปดาห์',
-    'day'       => '1 วัน|:count วัน',
-    'hour'      => '1 ชั่วโมง|:count ชั่วโมง',
-    'minute'    => '1 นาที|:count นาที',
-    'second'    => '1 วินาที|:count วินาที',
+    'ago'       => ':timeที่แล้ว',
+    'from_now'  => ':timeจากนี้',
+    'after'     => 'หลัง :time',
+    'before'    => 'ก่อน :time',
+    'year'      => ':count ปี',
+    'month'     => ':count เดือน',
+    'week'      => ':count สัปดาห์',
+    'day'       => ':count วัน',
+    'hour'      => ':count ชั่วโมง',
+    'minute'    => ':count นาที',
+    'second'    => ':count วินาที',
 
     'january'   => 'มกราคม',
     'february'  => 'กุมภาพันธ์',

--- a/tests/TranslationThTest.php
+++ b/tests/TranslationThTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use Jenssegers\Date\Date;
+
+class TranslationThTest extends PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        date_default_timezone_set('UTC');
+        Date::setLocale('th');
+    }
+
+    public function testTimespanTranslated()
+    {
+        $date = new Date(1403619368);
+        $date = $date->sub('-100 days -3 hours -20 minutes');
+
+        $this->assertSame('3 เดือน, 1 สัปดาห์, 1 วัน, 3 ชั่วโมง, 20 นาที', $date->timespan(1403619368));
+    }
+
+    public function testCreateFromFormat()
+    {
+        $date = Date::createFromFormat('d F Y', '1 มกราคม 2015');
+        $this->assertSame('2015-01-01', $date->format('Y-m-d'));
+
+        $date = Date::createFromFormat('D d F Y', 'เสาร์ 21 มีนาคม 2015');
+        $this->assertSame('2015-03-21', $date->format('Y-m-d'));
+    }
+
+    public function testAgoTranslated()
+    {
+        $date = Date::parse('-21 hours');
+        $this->assertSame('21 ชั่วโมงที่แล้ว', $date->ago());
+
+        $date = Date::parse('-5 days');
+        $this->assertSame('5 วันที่แล้ว', $date->ago());
+
+        $date = Date::parse('-3 weeks');
+        $this->assertSame('3 สัปดาห์ที่แล้ว', $date->ago());
+
+        $date = Date::parse('-6 months');
+        $this->assertSame('6 เดือนที่แล้ว', $date->ago());
+
+        $date = Date::parse('-10 years');
+        $this->assertSame('10 ปีที่แล้ว', $date->ago());
+    }
+
+    public function testFormatDeclensions()
+    {
+        $date = new Date('10 march 2015');
+        $this->assertSame('มีนาคม 2015', $date->format('F Y'));
+
+        $date = new Date('10 march 2015');
+        $this->assertSame('10 มีนาคม 2015', $date->format('j F Y'));
+    }
+
+    public function testAfterTranslated()
+    {
+        $date = Date::parse('+21 hours');
+        $this->assertSame('21 ชั่วโมงจากนี้', $date->ago());
+
+        $date = Date::parse('+5 days');
+        $this->assertSame('5 วันจากนี้', $date->ago());
+
+        $date = Date::parse('+3 weeks');
+        $this->assertSame('3 สัปดาห์จากนี้', $date->ago());
+
+        $date = Date::parse('+6 months');
+        $this->assertSame('6 เดือนจากนี้', $date->ago());
+
+        $date = Date::parse('+10 years');
+        $this->assertSame('10 ปีจากนี้', $date->ago());
+    }
+}


### PR DESCRIPTION
…stead of proper unit)

Date::setLocale('en');
$date = new Date('+1000 days');
dump(Date::now()->timespan($date));
English shows "2 years, 8 months, 3 weeks, 6 days"

Date::setLocale('th');
$date = new Date('+1000 days');
dump(Date::now()->timespan($date));
Thai shows "1 ปี, 1 เดือน, 1 สัปดาห์, 1 วัน"