### PR TITLE
Parse Carbon objects

### DIFF
--- a/src/Date.php
+++ b/src/Date.php
@@ -75,7 +75,16 @@ class Date extends Carbon
      */
     public static function parse($time = null, $timezone = null)
     {
-        $time = static::translateTimeString($time);
+        if ($time instanceof Carbon) {
+            return new static(
+                $time->toDateTimeString(),
+                $timezone ?: $time->getTimezone()
+            );
+        }
+
+        if (! is_int($time)) {
+            $time = static::translateTimeString($time);
+        }
 
         return new static($time, $timezone);
     }
@@ -274,8 +283,8 @@ class Date extends Carbon
         $lang = $this->getTranslator();
 
         // Create Date instance if needed
-        if (! $time instanceof self) {
-            $time = new static($time, $timezone);
+        if (! $time instanceof static) {
+            $time = Date::parse($time, $timezone);
         }
 
         $units = ['y' => 'year', 'm' => 'month', 'w' => 'week', 'd' => 'day', 'h' => 'hour', 'i' => 'minute', 's' => 'second'];

--- a/tests/DateTest.php
+++ b/tests/DateTest.php
@@ -64,7 +64,7 @@ class DateTest extends PHPUnit_Framework_TestCase
     public function testCreateFromCarbon()
     {
         $date = Date::make(Carbon::createFromFormat('U', 1367186296));
-        $this->assertInstanceOf(Date::class, $date);
+        $this->assertInstanceOf('Jenssegers\Date\Date', $date);
         $this->assertEquals(1367186296, $date->getTimestamp());
     }
 

--- a/tests/DateTest.php
+++ b/tests/DateTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\Carbon;
 use Jenssegers\Date\Date;
 
 class DateTest extends PHPUnit_Framework_TestCase
@@ -58,6 +59,13 @@ class DateTest extends PHPUnit_Framework_TestCase
         $now1 = Date::make('now');
         $now2 = new Date('now');
         $this->assertEquals($now1, $now2);
+    }
+
+    public function testCreateFromCarbon()
+    {
+        $date = Date::make(Carbon::createFromFormat('U', 1367186296));
+        $this->assertInstanceOf(Date::class, $date);
+        $this->assertEquals(1367186296, $date->getTimestamp());
     }
 
     public function testManipulation()


### PR DESCRIPTION
Allows for rapid conversion of plain Carbon objects.

```php
$carbon = Carbon::now();
$date = Date::parse($carbon);
```

L85 also allows Unix timestamps to be passed to `parse()`.