### PR TITLE
fix typo

### DIFF
--- a/src/Lang/ar.php
+++ b/src/Lang/ar.php
@@ -37,7 +37,7 @@ return [
     'november'  => 'نوفمبر',
     'december'  => 'ديسمبر',
 
-    'monday'    => 'الإثنين',
+    'monday'    => 'الاثنين',
     'tuesday'   => 'الثلاثاء',
     'wednesday' => 'الأربعاء',
     'thursday'  => 'الخميس',


### PR DESCRIPTION
The "monday" word in arabic is from "اثنين" (two) with 'hamzat wasl' `ا` (همزة وصل) not 'hamzat khataa' `إ` (همزة قطع) !