### PR TITLE
Minor change for Arabic translation regarding (from now :time)

### DIFF
--- a/src/Lang/ar.php
+++ b/src/Lang/ar.php
@@ -13,7 +13,7 @@ return [
     */
 
     'ago'       => 'منذ :time',
-    'from_now'  => 'من الآن :time',
+    'from_now'  => ':time من الآن',
     'after'     => 'بعد :time',
     'before'    => 'قبل :time',
     'year'      => '{0}سنة|{1}سنة|{2}سنتين|[3,10]:count سنوات|[11,Inf]:count سنة',


### PR DESCRIPTION
In Arabic we don't say (from now :time) we say (:time from now):

Arabic examples:
من الآن 8 أشهر
8 أشهر من الآن 

The line at the very above this one might seem strange that is because Github's website is LTR, not RTL!

I ran into this problem in multiple projects, so please accept this minor change.

BTW:

How can I add another Arabic language? like ar_SY?

In Syria, we call the months by different names! please tell me how can I do so by telling me or sharing a link. thanks in advance