### PR TITLE
Fix locale change when App::setLocale() is called

### DIFF
--- a/src/DateServiceProvider.php
+++ b/src/DateServiceProvider.php
@@ -18,9 +18,15 @@ class DateServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->app['events']->listen('locale.changed', function () {
-            $this->setLocale();
-        });
+        if (version_compare(\App::version(), '5.5') >= 0) {
+            $this->app['events']->listen(LocaleUpdated::class, function() {
+                $this->setLocale();
+            });
+        } else {
+            $this->app['events']->listen('locale.changed', function () {
+                $this->setLocale();
+            });
+        }
 
         $this->setLocale();
     }


### PR DESCRIPTION
Added a version check because I was unable to test other Laravel versions at the time that I wrote this quick fix.

But Laravel seems to have changed the locale change event anyway.