### PR TITLE
Fixed Ukrainian translation for `ago` line.

### DIFF
--- a/src/Lang/uk.php
+++ b/src/Lang/uk.php
@@ -12,7 +12,7 @@ return [
     |
     */
 
-    'ago'       => ':time назад',
+    'ago'       => ':time тому',
     'from_now'  => 'через :time',
     'after'     => ':time після',
     'before'    => ':time до',


### PR DESCRIPTION
Fixed mistake in Ukrainian translation line`ago`.

```php
use Jenssegers\Date\Date;

Date::setLocale('uk');
Date::now()->subMinutes(30)->diffForHumans(); // "30 хвилин тому" instead of "30 хвилин назад"
```