### PR TITLE
Add Nepali (ne) Locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ This package contains language files for the following languages:
  - Macedonian
  - Malay
  - Norwegian
+ - Nepali (नेपाली)
  - Polish
  - Portuguese
  - Persian (Farsi)

--- a/src/Lang/ne.php
+++ b/src/Lang/ne.php
@@ -13,7 +13,7 @@ return [
     */
 
     'ago'       => ':time पहिले',
-    'from_now'  => ':time देखी',
+    'from_now'  => ':time देखि',
     'after'     => ':time पछि',
     'before'    => ':time अघि',
     'year'      => ':count वर्ष',
@@ -24,7 +24,7 @@ return [
     'minute'    => ':count मिनेट',
     'second'    => ':count सेकेण्ड',
 
-    'january'   => 'जेनवरी',
+    'january'   => 'जनवरी',
     'february'  => 'फेब्रुअरी',
     'march'     => 'मार्च',
     'april'     => 'अप्रिल',
@@ -37,13 +37,13 @@ return [
     'november'  => 'नोभेम्बर',
     'december'  => 'डिसेम्बर',
 
-    'sunday'    => 'आइतवार',
-    'monday'    => 'सोमवार',
-    'tuesday'   => 'मङ्गलवार',
-    'wednesday' => 'बुधवार',
-    'thursday'  => 'बिहिवार',
-    'friday'    => 'शुक्रवार',
-    'saturday'  => 'शनिवार',
+    'sunday'    => 'आइतबार',
+    'monday'    => 'सोमबार',
+    'tuesday'   => 'मङ्गलबार',
+    'wednesday' => 'बुधबार',
+    'thursday'  => 'बिहिबार',
+    'friday'    => 'शुक्रबार',
+    'saturday'  => 'शनिबार',
 
     'sun'       => 'आइत',
     'mon'       => 'सोम',

--- a/src/Lang/ne.php
+++ b/src/Lang/ne.php
@@ -1,0 +1,56 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Date Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the date library. Each line can
+    | have a singular and plural translation separated by a '|'.
+    |
+    */
+
+    'ago'       => ':time पहिले',
+    'from_now'  => ':time देखी',
+    'after'     => ':time पछि',
+    'before'    => ':time अघि',
+    'year'      => ':count वर्ष',
+    'month'     => ':count महिना',
+    'week'      => ':count हप्ता',
+    'day'       => ':count दिन',
+    'hour'      => ':count घण्टा',
+    'minute'    => ':count मिनेट',
+    'second'    => ':count सेकेण्ड',
+
+    'january'   => 'जेनवरी',
+    'february'  => 'फेब्रुअरी',
+    'march'     => 'मार्च',
+    'april'     => 'अप्रिल',
+    'may'       => 'मे',
+    'june'      => 'जून',
+    'july'      => 'जूलाई',
+    'august'    => 'अगस्ट',
+    'september' => 'सेप्टेम्बर',
+    'october'   => 'अक्टोबर',
+    'november'  => 'नोभेम्बर',
+    'december'  => 'डिसेम्बर',
+
+    'sunday'    => 'आइतवार',
+    'monday'    => 'सोमवार',
+    'tuesday'   => 'मङ्गलवार',
+    'wednesday' => 'बुधवार',
+    'thursday'  => 'बिहिवार',
+    'friday'    => 'शुक्रवार',
+    'saturday'  => 'शनिवार',
+
+    'sun'       => 'आइत',
+    'mon'       => 'सोम',
+    'tue'       => 'मङ्गल',
+    'wed'       => 'बुध',
+    'thu'       => 'बिहि',
+    'fri'       => 'शुक्र',
+    'sat'       => 'शनि',
+
+];


### PR DESCRIPTION
Notes:
  - Month names are transliterated. Wikipedia was used as source.
  - Similarly, 'second' and 'minute' are transliterated. 