### PR TITLE
Declension detection enhancement.

### DIFF
--- a/src/Date.php
+++ b/src/Date.php
@@ -237,10 +237,10 @@ class Date extends Carbon
                 // Translate.
                 $lang = $this->getTranslator();
 
-                // For declension support, we need to check if the month is lead by a numeric number.
+                // For declension support, we need to check if the month is lead by a day number.
                 // If so, we will use the second translation choice if it is available.
                 if (in_array($character, ['F', 'M'])) {
-                    $choice = (($i - 2) >= 0 and in_array($format[$i - 2], ['d', 'j'])) ? 1 : 0;
+                    $choice = preg_match('#[dj][ .]*$#', substr($format, 0, $i)) ? 1 : 0;
 
                     $translated = $lang->transChoice(mb_strtolower($key), $choice);
                 } else {

--- a/tests/TranslationTest.php
+++ b/tests/TranslationTest.php
@@ -172,6 +172,9 @@ class TranslationTest extends TestCase
 
         $date = new Date('10 march 2015');
         $this->assertSame('10 мартa 2015', $date->format('j F Y'));
+
+        $date = new Date('10 march 2015');
+        $this->assertSame('10. мартa 2015', $date->format('j. F Y'));
     }
 
     public function testTranslateTimeString()


### PR DESCRIPTION
Library offers months declension for formats like `j F Y`. This doesn't work for valid Czech date formatting (`j. F Y` - e. g. _18. prosince 2017_). PR fixes that and allows a month name to be prefixed not only by a space, but a dot as well.