### PR TITLE
Add a test for Carbon future release compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ php:
 sudo: false
 
 matrix:
+  include:
+    - php: 7.2
+      env:
+        - CARBON_PRE_RELEASE='yes'
   fast_finish: true
   allow_failures:
     - php: hhvm
@@ -20,6 +24,7 @@ before_install:
   - travis_retry composer self-update
 
 install:
+  - if [[ $CARBON_PRE_RELEASE == "yes" ]]; then travis_retry composer require nesbot/carbon=dev-master; fi;
   - travis_retry composer update --dev --no-interaction --prefer-source
 
 script:


### PR DESCRIPTION
- This will allow to check jenssegers/date does not fail with next Carbon release
- This should be paired with daily/weekly CRON job added in the TravisCI panel