### PR TITLE
[Unit tests] Use the same timestamp everywhere

### DIFF
--- a/tests/DateTest.php
+++ b/tests/DateTest.php
@@ -80,7 +80,7 @@ class DateTest extends TestCase
         $this->assertSame(-86400, $now->copy()->sub('1 day')->getTimestamp() - $now->getTimestamp());
         $this->assertSame(-4 * 86400, $now->copy()->sub('4 day')->getTimestamp() - $now->getTimestamp());
 
-        $this->assertSame(10 * 86400, $now->copy()->add('P10D')->getTimestamp() - $now->->getTimestamp());
+        $this->assertSame(10 * 86400, $now->copy()->add('P10D')->getTimestamp() - $now->getTimestamp());
         $this->assertSame(-10 * 86400, $now->copy()->sub('P10D')->getTimestamp() - $now->getTimestamp());
     }
 

--- a/tests/DateTest.php
+++ b/tests/DateTest.php
@@ -69,17 +69,19 @@ class DateTest extends TestCase
 
     public function testManipulation()
     {
-        $this->assertInstanceOf('Jenssegers\Date\Date', Date::now()->add('1 day'));
-        $this->assertInstanceOf('Jenssegers\Date\Date', Date::now()->sub('1 day'));
+        $now = Date::now();
 
-        $this->assertSame(86400, Date::now()->add('1 day')->getTimestamp() - Date::now()->getTimestamp());
-        $this->assertSame(4 * 86400, Date::now()->add('4 day')->getTimestamp() - Date::now()->getTimestamp());
+        $this->assertInstanceOf('Jenssegers\Date\Date', $now->copy()->add('1 day'));
+        $this->assertInstanceOf('Jenssegers\Date\Date', $now->copy()->sub('1 day'));
 
-        $this->assertSame(-86400, Date::now()->sub('1 day')->getTimestamp() - Date::now()->getTimestamp());
-        $this->assertSame(-4 * 86400, Date::now()->sub('4 day')->getTimestamp() - Date::now()->getTimestamp());
+        $this->assertSame(86400, $now->copy()->add('1 day')->getTimestamp() - $now->getTimestamp());
+        $this->assertSame(4 * 86400, $now->copy()->add('4 day')->getTimestamp() - $now->getTimestamp());
 
-        $this->assertSame(10 * 86400, Date::now()->add('P10D')->getTimestamp() - Date::now()->getTimestamp());
-        $this->assertSame(-10 * 86400, Date::now()->sub('P10D')->getTimestamp() - Date::now()->getTimestamp());
+        $this->assertSame(-86400, $now->copy()->sub('1 day')->getTimestamp() - $now->getTimestamp());
+        $this->assertSame(-4 * 86400, $now->copy()->sub('4 day')->getTimestamp() - $now->getTimestamp());
+
+        $this->assertSame(10 * 86400, $now->copy()->add('P10D')->getTimestamp() - $now->->getTimestamp());
+        $this->assertSame(-10 * 86400, $now->copy()->sub('P10D')->getTimestamp() - $now->getTimestamp());
     }
 
     public function testFormat()

--- a/tests/TranslationTest.php
+++ b/tests/TranslationTest.php
@@ -106,6 +106,7 @@ class TranslationTest extends TestCase
     public function testAgoTranslated()
     {
         Date::setLocale('nl');
+        Date::setTestNow(Date::now());
 
         $date = Date::parse('-5 years');
         $this->assertSame('5 jaar geleden', $date->ago());


### PR DESCRIPTION
This test can fail, because each time you can `Date:now()`, there is no guarantee the timestamp did not change meanwhile.