### PR TITLE
Extend from Illuminate\Support\Carbon if applicable

### DIFF
--- a/src/Date.php
+++ b/src/Date.php
@@ -9,7 +9,13 @@ use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Translator;
 use Symfony\Component\Translation\TranslatorInterface;
 
-class Date extends Carbon
+if (class_exists('Illuminate\Support\Carbon')) {
+    class BaseCarbon extends \Illuminate\Support\Carbon {}
+} else {
+    class BaseCarbon extends Carbon {}
+}
+
+class Date extends BaseCarbon
 {
     /**
      * The Translator implementation.


### PR DESCRIPTION
Laravel provides its own extension of Carbon with minimal but important changes. This PR makes the `Date` class extend from Illuminate's version if it's present.

Important use case: macros/mixins.
-> Registering a macro on `Illuminate\Support\Carbon` is currently useless since `Date` directly extends `Carbon\Carbon`. 