### PR TITLE
Create ku.php for the Kurdish Language

### DIFF
--- a/src/Lang/ku.php
+++ b/src/Lang/ku.php
@@ -1,0 +1,44 @@
+<?php
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Date Language Lines
+    |--------------------------------------------------------------------------
+    | Langauge: Kurdish
+    | Dilect: Central Kurdish
+    |
+    | The following language lines are used by the date library. Each line can
+    | have a singular and plural translation separated by a '|'.
+    |
+    */
+    'ago' => 'لەمەوبەر :time',
+    'from_now' => ':time لە ئێستاوە',
+    'after' => 'دوای :time',
+    'before' => 'پێش :time',
+    'year' => '{0}ساڵ|{1}ساڵ|{2}ساڵ|[3,10]:count ساڵ|[11,Inf]:count ساڵ',
+    'month' => '{0}مانگ|{1}مانگ|{2}مانگ|[3,10]:count مانگ|[11,Inf]:count مانگ',
+    'week' => '{0}هەفتە|{1}هەفتە|{2}هەفتە|[3,10]:count هەفتە|[11,Inf]:count هەفتە',
+    'day' => '{0}ڕۆژ|{1}ڕۆژ|{2}ڕۆژ|[3,10]:count ڕۆژ|[11,Inf]:count ڕۆژ',
+    'hour' => '{0}کاژێر|{1}کاژێر|{2}کاژێر|[3,10]:count کاژێر|[11,Inf]:count کاژێر',
+    'minute' => '{0}خولەک|{1}خولەک|{2}خولەک|[3,10]:count خولەک|[11,Inf]:count خولەک',
+    'second' => '{0}چرکە|{1}چرکە|{2}چرکە|[3,10]:count چرکە|[11,Inf]:count چرکە',
+    'january' => 'کانونی دووەم',
+    'february' => 'شوبات',
+    'march' => 'ئازار',
+    'april' => 'نیسان',
+    'may' => 'ئایار',
+    'june' => '‌حوزەیران',
+    'july' => 'تەمموز',
+    'august' => 'ئاب',
+    'september' => 'ئەیلول',
+    'october' => 'تشرینی یەکەم',
+    'november' => 'تشرینی دووەم',
+    'december' => 'کانونی یەکەم',
+    'monday' => 'دوو شەممە',
+    'tuesday' => 'سێ شەممە',
+    'wednesday' => 'چوار شەممە',
+    'thursday' => 'پێنج شەممە',
+    'friday' => 'هەینی',
+    'saturday' => 'شەممە',
+    'sunday' => 'یەک شەممە',
+];


### PR DESCRIPTION
thanks, @kylekatarnls for your response,

We have two of most used dialects in the Kurdish language:

ckb: Central Kurdish (used by Kurdish people in Iraq and Iran)
Ku: Kurmanji (used by Kurdish people in Turkey and Syria)

and they are different from writing alphabets and speaking, so they are used on Facebook, Check this:
https://developers.facebook.com/docs/messenger-platform/messenger-profile/supported-locales

ku: Kurmanji Kurdish: facebook code = ku_TR
ckb: Central Kurdish: facebook code = cb_IQ

and I'm from the part of Kurdistan of Iraq. that's a reason that why I asking for the ckb version of the Kurdish language.

best regards.