### PR TITLE
Update dependencies to retain framework compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
         }
     ],
     "require": {
-        "nesbot/carbon": "^2.16"
+        "nesbot/carbon": "^2.72.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5",
-        "satooshi/php-coveralls": "^2.0"
+        "phpunit/phpunit": "^10.4.0",
+        "php-coveralls/php-coveralls": "^2.7"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
->
-    <testsuites>
-        <testsuite name="all">
-            <directory>tests/</directory>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="all">
+      <directory>tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/tests/TestCaseBase.php
+++ b/tests/TestCaseBase.php
@@ -11,7 +11,7 @@ class TestCaseBase extends TestCase
 
     protected $time;
 
-    public function setUp()
+    public function setUp(): void
     {
         date_default_timezone_set('UTC');
         Carbon::setLocale(static::LOCALE);

--- a/tests/TranslationKaTest.php
+++ b/tests/TranslationKaTest.php
@@ -46,10 +46,10 @@ class TranslationKaTest extends TestCaseBase
     public function testFormatDeclensions()
     {
         $date = new Date('10 march 2015');
-        $this->assertSame('მარტი 2015', $date->format('F Y'));
+        $this->assertSame('მარტს 2015', $date->format('F Y'));
 
         $date = new Date('10 march 2015');
-        $this->assertSame('10 მარტს 2015', $date->format('j F Y'));
+        $this->assertSame('10 მარტი 2015', $date->format('j F Y'));
     }
 
     public function testAfterTranslated()


### PR DESCRIPTION
It appears one unit test had the values switched. However I can't verify if it's the code or the test that's wrong.